### PR TITLE
remove hello world from default title

### DIFF
--- a/src/cfalert-dialog.ios.ts
+++ b/src/cfalert-dialog.ios.ts
@@ -62,7 +62,7 @@ export interface DialogOptions {
 
 const DEFAULT_DIALOG_OPTIONS: DialogOptions = {
   dialogStyle: CFAlertStyle.ALERT,
-  title: 'Hello world!',
+  title: '',
   titleColor: 'black',
   messageColor: 'black',
   cancellable: true,


### PR DESCRIPTION
To show an alert without a title in the default args.